### PR TITLE
Move CLI into bin with module support

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -1,4 +1,5 @@
-// create.mjs
+#!/usr/bin/env node
+// create.js
 import inquirer from "inquirer";
 import shell from "shelljs";
 import fs from "fs";

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "projects",
   "version": "1.0.0",
   "description": "",
-  "main": "create.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
+  "bin": {
+    "forgekit": "./bin/create.js"
+  },
   "dependencies": {
     "inquirer": "^12.5.0",
     "shelljs": "^0.9.2"


### PR DESCRIPTION
## Summary
- expose `forgekit` CLI via `bin/create.js`
- remove old `create.mjs`
- make package a module and declare `forgekit` bin

## Testing
- `npm pack`