### PR TITLE
Add global forge CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ ForgeKit is a modular scaffolding tool that helps you spin up full‑stack proje
 
 ## Example Usage
 
-Run the script directly to create a project:
+Install the package globally and run the CLI:
 
 ```bash
-node create.mjs
+npm install -g forgekit
+forge my-app
 ```
 
 The tool can also be configured programmatically. Example configuration from the project plan:
@@ -28,10 +29,10 @@ The tool can also be configured programmatically. Example configuration from the
 }
 ```
 
-Future releases will support an npm‑published CLI so you can simply run:
+You can also use `npx` without installing globally:
 
 ```bash
-npx create-forgekit my-app
+npx forge my-app
 ```
 
 ## Purpose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "projects",
+  "name": "forgekit",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "projects",
+      "name": "forgekit",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "inquirer": "^12.5.0",
         "shelljs": "^0.9.2"
       },
       "bin": {
-        "forgekit": "bin/create.js"
+        "forge": "bin/create.js"
       }
     },
     "node_modules/@inquirer/checkbox": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-  "name": "projects",
+  "name": "forgekit",
   "version": "1.0.0",
 
   "description": "Modular full-stack project scaffolding tool",
-  "main": "create.js",
+  "main": "src/scaffold.js",
+  "bin": {
+    "forge": "./bin/create.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "ForgeKit Contributors",
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "inquirer": "^12.5.0",
     "shelljs": "^0.9.2"


### PR DESCRIPTION
## Summary
- expose `forge` binary via npm
- switch package to ESM and name `forgekit`
- document installation and usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*