### PR TITLE
Fix CLI path handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ Install the package globally and run the CLI:
 
 ```bash
 npm install -g forgekit
-forge my-app
+forge
 ```
+
+Running `forge` will prompt you for a project name and desired stack. The
+project is created in the directory where you executed the command, and when
+scaffolding finishes you will be dropped into a shell inside the new project
+folder.
 
 The tool can also be configured programmatically. Example configuration from the project plan:
 
@@ -32,8 +37,10 @@ The tool can also be configured programmatically. Example configuration from the
 You can also use `npx` without installing globally:
 
 ```bash
-npx forge my-app
+npx forge
 ```
+This behaves the same as the global install, prompting for details and placing
+you in the newly created project directory when finished.
 
 ## Purpose
 

--- a/bin/create.js
+++ b/bin/create.js
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { fileURLToPath } from 'url';
 import { drawForgeHammer, setupGit, createProjectStructure, sanitizeProjectName } from '../src/utils.js';
 import { spawn } from 'child_process';
 import { scaffoldProject } from '../src/scaffold.js';
@@ -12,15 +11,8 @@ import { stacks } from '../src/registries/stackRegistry.js';
 
 
 (async () => {
-  let projectsBaseDir;
-  try {
-      const __filename = fileURLToPath(import.meta.url);
-      const createScriptDir = path.dirname(__filename);
-      projectsBaseDir = path.dirname(createScriptDir);
-  } catch (e) {
-      console.error('❌ Error determining script location.');
-      process.exit(1);
-  }
+  // Use the directory where the user ran the command
+  const projectsBaseDir = process.cwd();
 
   const stackKeys = Object.keys(stacks);
   const argv = yargs(hideBin(process.argv))

--- a/package.json
+++ b/package.json
@@ -30,11 +30,6 @@
     "shelljs": "^0.9.2",
     "yargs": "^17.7.2"
   },
-
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/forgekit/forgekit.git"
-  },
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
## Summary
- create projects in the current working directory instead of relative to the install path
- remove duplicate `repository` field from `package.json`
- update README usage instructions

## Testing
- `npm test`