### PR TITLE
Add doctor command and PATH postinstall check

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ npx @forgekit/cli
 This behaves the same as the global install, prompting for details and placing
 you in the newly created project directory when finished.
 
+If the `forge` command is not found after a global install, ensure your npm
+global bin directory is in your `PATH`.
+You can typically add it with:
+
+```bash
+export PATH="$PATH:$(npm bin -g)"
+```
+
+You can verify your environment at any time with the built in doctor command:
+
+```bash
+forge --doctor
+```
+
 ## Purpose
 
 ForgeKit aims to streamline bootstrapping modern JavaScript projects by providing a collection of ready‑to‑use stacks with minimal setup hassle.

--- a/bin/create.js
+++ b/bin/create.js
@@ -8,6 +8,7 @@ import { drawForgeHammer, setupGit, createProjectStructure, sanitizeProjectName 
 import { spawn } from 'child_process';
 import { scaffoldProject } from '../src/scaffold.js';
 import { stacks } from '../src/registries/stackRegistry.js';
+import { runDoctor } from '../src/doctor.js';
 
 
 (async () => {
@@ -23,10 +24,16 @@ import { stacks } from '../src/registries/stackRegistry.js';
     .option('uiFramework', { type: 'string', description: 'UI framework', choices: ['Tailwind', 'Chakra', 'None'], default: 'None' })
     .option('storybook', { type: 'boolean', description: 'Include Storybook setup', default: false })
     .option('nonInteractive', { type: 'boolean', description: 'Run in non-interactive mode', default: false })
+    .option('doctor', { type: 'boolean', description: 'Check ForgeKit installation status' })
     .help()
     .alias('h', 'help')
     .wrap(null)
     .argv;
+
+  if (argv.doctor) {
+    runDoctor();
+    process.exit(0);
+  }
 
   let options = {};
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "test": "node test/stack-implementation.test.js",
-    "generate-stack-docs": "node scripts/generate-stack-docs.js"
+    "generate-stack-docs": "node scripts/generate-stack-docs.js",
+    "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
     "inquirer": "^12.5.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,15 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import process from 'process';
+
+try {
+  const globalBin = execSync('npm bin -g').toString().trim();
+  const paths = process.env.PATH.split(path.delimiter);
+  if (!paths.includes(globalBin)) {
+    console.warn('\n⚠️  The npm global bin directory is not in your PATH.');
+    console.warn(`Add it permanently by appending this line to your shell profile:\n`);
+    console.warn(`  export PATH=\"$PATH:${globalBin}\"`);
+  }
+} catch (err) {
+  // swallow errors; this is a best-effort message
+}

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import process from 'process';
+
+export function runDoctor() {
+  console.log('\n🩺 Running ForgeKit doctor...');
+  let ok = true;
+
+  function check(cmd, name) {
+    try {
+      const output = execSync(cmd, { stdio: 'pipe' }).toString().trim();
+      console.log(`✓ ${name}: ${output}`);
+    } catch {
+      console.error(`✖ ${name} not found in PATH`);
+      ok = false;
+    }
+  }
+
+  check('node -v', 'Node.js');
+  check('npm -v', 'npm');
+  check('git --version', 'git');
+
+  try {
+    const globalBin = execSync('npm bin -g').toString().trim();
+    const paths = process.env.PATH.split(path.delimiter);
+    if (!paths.includes(globalBin)) {
+      console.warn(`⚠️  npm global bin directory not in PATH`);
+      console.warn(`   Add it with: export PATH=\"$PATH:${globalBin}\"`);
+      ok = false;
+    } else {
+      console.log('✓ npm global bin in PATH');
+    }
+  } catch {
+    // ignore
+  }
+
+  if (ok) {
+    console.log('\nForgeKit environment looks good!');
+  } else {
+    console.log('\nSome issues were detected. Please resolve them and try again.');
+  }
+}


### PR DESCRIPTION
## Summary
- show warning on postinstall if npm global bin isn't in PATH
- add a doctor utility and expose `--doctor` flag
- document how to fix PATH issues and use the doctor command

## Testing
- `npm test`