### PR TITLE
Fix express scaffolder port variable interpolation

### DIFF
--- a/src/stacks/backend/express.js
+++ b/src/stacks/backend/express.js
@@ -66,7 +66,7 @@ app.get('/api/message', (req: Request, res: Response) => {
 });
 
 app.listen(port, () => {
-  console.log(\`🚀 Backend server listening on http://localhost:${port}\`);
+  console.log(\`🚀 Backend server listening on http://localhost:\${port}\`);
 });`;
   fs.writeFileSync(path.join(backendSrcDir, 'index.ts'), indexTsContent);
   console.log(`↳ Created src/index.ts in backend`);


### PR DESCRIPTION
## Summary
- fix `port` interpolation when generating Express backend

## Testing
- `npm test`