### PR TITLE
Use checkCommand in backend setup scripts

### DIFF
--- a/src/stacks/backend/django.js
+++ b/src/stacks/backend/django.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
+import { checkCommand } from '../../utils.js';
 
 export async function setupDjango(config) {
   const { targetDir, projectName } = config;
@@ -9,9 +10,14 @@ export async function setupDjango(config) {
   console.log('\n◀️ Setting up backend (Django)...');
   fs.mkdirSync(backendDir, { recursive: true });
 
-  shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
-  shell.exec('venv/bin/pip install django', { cwd: backendDir, silent: true });
-  shell.exec(`venv/bin/django-admin startproject ${projectName} .`, { cwd: backendDir, silent: true });
+  let result = shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to create Python venv for Django');
+
+  result = shell.exec('venv/bin/pip install django', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to install Django');
+
+  result = shell.exec(`venv/bin/django-admin startproject ${projectName} .`, { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to start Django project');
 
   fs.writeFileSync(path.join(backendDir, 'requirements.txt'), 'django\n');
 }

--- a/src/stacks/backend/fastapi.js
+++ b/src/stacks/backend/fastapi.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
+import { checkCommand } from '../../utils.js';
 
 export async function setupFastAPI(config) {
   const { targetDir } = config;
@@ -13,6 +14,9 @@ export async function setupFastAPI(config) {
   const mainPy = `from fastapi import FastAPI\n\napp = FastAPI()\n\n@app.get('/')\nasync def root():\n    return {'message': 'Hello from FastAPI'}\n`;
   fs.writeFileSync(path.join(backendDir, 'main.py'), mainPy);
 
-  shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
-  shell.exec('venv/bin/pip install -r requirements.txt', { cwd: backendDir, silent: true });
+  let result = shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to create Python venv for FastAPI');
+
+  result = shell.exec('venv/bin/pip install -r requirements.txt', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to install FastAPI dependencies');
 }

--- a/src/stacks/backend/flask.js
+++ b/src/stacks/backend/flask.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
+import { checkCommand } from '../../utils.js';
 
 export async function setupFlask(config) {
   const { targetDir } = config;
@@ -13,6 +14,9 @@ export async function setupFlask(config) {
   const appPy = `from flask import Flask\napp = Flask(__name__)\n\n@app.route('/')\ndef index():\n    return 'Hello from Flask!'\n\nif __name__ == '__main__':\n    app.run(debug=True, port=3001)\n`;
   fs.writeFileSync(path.join(backendDir, 'app.py'), appPy);
 
-  shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
-  shell.exec('venv/bin/pip install -r requirements.txt', { cwd: backendDir, silent: true });
+  let result = shell.exec('python3 -m venv venv', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to create Python venv for Flask');
+
+  result = shell.exec('venv/bin/pip install -r requirements.txt', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to install Flask dependencies');
 }

--- a/src/stacks/backend/gofiber.js
+++ b/src/stacks/backend/gofiber.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
+import { checkCommand } from '../../utils.js';
 
 export async function setupGoFiber(config) {
   const { targetDir, projectName } = config;
@@ -9,8 +10,11 @@ export async function setupGoFiber(config) {
   console.log('\n◀️ Setting up backend (Go Fiber)...');
   fs.mkdirSync(backendDir, { recursive: true });
 
-  shell.exec(`go mod init ${projectName}`, { cwd: backendDir, silent: true });
-  shell.exec('go get github.com/gofiber/fiber/v2', { cwd: backendDir, silent: true });
+  let result = shell.exec(`go mod init ${projectName}`, { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to initialize Go module');
+
+  result = shell.exec('go get github.com/gofiber/fiber/v2', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to get Go Fiber dependency');
 
   const mainGo = `package main\n\nimport \"github.com/gofiber/fiber/v2\"\n\nfunc main() {\n  app := fiber.New()\n  app.Get(\"/\", func(c *fiber.Ctx) error {\n    return c.SendString(\"Hello from Go Fiber!\")\n  })\n  app.Listen(\":3001\")\n}`;
   fs.writeFileSync(path.join(backendDir, 'main.go'), mainGo);

--- a/src/stacks/backend/spring-boot.js
+++ b/src/stacks/backend/spring-boot.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import shell from 'shelljs';
+import { checkCommand } from '../../utils.js';
 
 export async function setupSpringBoot(config) {
   const { targetDir, projectName } = config;
@@ -9,7 +10,8 @@ export async function setupSpringBoot(config) {
   console.log('\n◀️ Setting up backend (Spring Boot)...');
   fs.mkdirSync(backendDir, { recursive: true });
 
-  shell.exec('mvn -q archetype:generate -DgroupId=com.example -DartifactId=backend -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false', { cwd: backendDir, silent: true });
+  let result = shell.exec('mvn -q archetype:generate -DgroupId=com.example -DartifactId=backend -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false', { cwd: backendDir, silent: true });
+  checkCommand(result, 'Failed to generate Spring Boot project');
 
   const appJavaDir = path.join(backendDir, 'src', 'main', 'java', 'com', 'example');
   fs.mkdirSync(appJavaDir, { recursive: true });


### PR DESCRIPTION
## Summary
- add `checkCommand` checks to FastAPI, Flask, Django, Go Fiber and Spring Boot backend scaffolds

## Testing
- `npm test` *(fails: Cannot find module '/workspace/forgekit/test/stack-implementation.test.js')*