### PR TITLE
Fix Chakra Vue integration

### DIFF
--- a/src/stacks/frontend/vue-vite.js
+++ b/src/stacks/frontend/vue-vite.js
@@ -36,8 +36,14 @@ export async function setupVueVite(config) {
 
   if (fs.existsSync(mainTsPath)) {
     let mainContent = fs.readFileSync(mainTsPath, 'utf-8');
-    if (ui === 'Chakra' && !mainContent.includes('ChakraProvider')) {
-      mainContent = mainContent.replace('createApp(App)', 'createApp(App)'); // placeholder for modifications
+    if (ui === 'Chakra') {
+      mainContent = `import { createApp } from 'vue';\n` +
+        `import App from './App.vue';\n` +
+        `import { ChakraPlugin } from '@chakra-ui/vue-next';\n` +
+        `import './style.css';\n\n` +
+        `const app = createApp(App);\n` +
+        `app.use(ChakraPlugin);\n` +
+        `app.mount('#app');\n`;
     }
     fs.writeFileSync(mainTsPath, mainContent);
   }


### PR DESCRIPTION
## Summary
- fix placeholder main.ts modification in Vue-Vite stack
- wrap Vue app with ChakraProvider example

## Testing
- `npm test` *(fails: Cannot find module 'test/stack-implementation.test.js')*