### PR TITLE
Add gitInit flag to project creation

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -99,7 +99,14 @@ import { runDoctor } from '../src/doctor.js';
   }
 
   if (options.frontend !== 'nextjs') {
-    createProjectStructure(projectRoot, options.projectName, { frontend: frontendOptions[options.frontend], backend: backendOptions[options.backend] }, options.ui, options.database);
+    createProjectStructure(
+      projectRoot,
+      options.projectName,
+      { frontend: frontendOptions[options.frontend], backend: backendOptions[options.backend] },
+      options.ui,
+      options.database,
+      options.gitInit
+    );
   }
 
   if (options.gitInit) {
@@ -118,7 +125,8 @@ import { runDoctor } from '../src/doctor.js';
     ui: options.ui,
     useNodemon: options.useNodemon,
     database: options.database,
-    stackLabel: `${frontendOptions[options.frontend]}${options.backend ? ' + ' + backendOptions[options.backend] : ''}`
+    stackLabel: `${frontendOptions[options.frontend]}${options.backend ? ' + ' + backendOptions[options.backend] : ''}`,
+    gitInit: options.gitInit
   };
 
   try {

--- a/src/stacks/frontend/nextjs.js
+++ b/src/stacks/frontend/nextjs.js
@@ -23,7 +23,7 @@ export async function setupNextJS(config) {
   if (result.code !== 0) throw new Error(`Failed to create Next.js project '${projectName}': ${result.stderr || result.stdout}`);
 
   console.log("\n📝 Adding DevForge structure files...");
-  createProjectStructure(targetDir, projectName, stackLabel, ui, config.database);
+  createProjectStructure(targetDir, projectName, stackLabel, ui, config.database, config.gitInit);
 
   await setupSupabase(targetDir, 'NEXT_PUBLIC');
   if (ui !== 'Tailwind') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,7 +61,7 @@ export async function setupGit(projectRoot) {
   checkCommand(result, `Failed to initialize git repository in ${projectRoot}. Is git installed and in your PATH?`);
 }
 
-export function createProjectStructure(projectRoot, projectName, stack, uiFramework, database) {
+export function createProjectStructure(projectRoot, projectName, stack, uiFramework, database, gitInit = true) {
   console.log(`\n🏗️ Creating project structure for '${projectName}' at ${projectRoot}...`);
   fs.mkdirSync(projectRoot, { recursive: true });
 
@@ -75,9 +75,11 @@ export function createProjectStructure(projectRoot, projectName, stack, uiFramew
   fs.writeFileSync(path.join(projectRoot, "CHANGELOG.md"), changelogContent);
   console.log("↳ Created CHANGELOG.md");
 
-  const gitignoreContent = generateGitignore(stack);
-  fs.writeFileSync(path.join(projectRoot, ".gitignore"), gitignoreContent);
-  console.log("↳ Created .gitignore");
+  if (gitInit) {
+    const gitignoreContent = generateGitignore(stack);
+    fs.writeFileSync(path.join(projectRoot, ".gitignore"), gitignoreContent);
+    console.log("↳ Created .gitignore");
+  }
 }
 
 export function generateReadme(projectRoot, projectName, stack, uiFramework, database) {


### PR DESCRIPTION
## Summary
- add optional `gitInit` parameter to `createProjectStructure`
- pass `gitInit` flag from CLI
- respect `gitInit` when initializing Next.js projects

## Testing
- `npm test`