### PR TITLE
Remove global UI framework install

### DIFF
--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -7,6 +7,8 @@ export async function scaffoldProject(config) {
   const { frontend, backend, ui, targetDir } = config;
 
   if (frontendStacks[frontend]) await frontendStacks[frontend].setup(config);
-  if (uiFrameworks[ui]) await uiFrameworks[ui].install(frontend === 'nextjs' ? targetDir : path.join(targetDir, 'frontend'), frontend);
+  // Individual frontend stacks handle UI framework installation via
+  // `setupUIFramework` internally.
+  // if (uiFrameworks[ui]) await uiFrameworks[ui].install(frontend === 'nextjs' ? targetDir : path.join(targetDir, 'frontend'), frontend);
   if (backend && backendStacks[backend]) await backendStacks[backend].setup(config);
 }


### PR DESCRIPTION
## Summary
- avoid calling `uiFrameworks[ui].install` from `scaffoldProject`
- rely on frontend stack setup to handle UI frameworks

## Testing
- `npm test`