### PR TITLE
Improve deploy flexibility and auto-detect build dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,17 @@ forge --doctor
 Run this command to publish your project. It will:
 
 - Build the project.
-- Bundle the `dist/` directory into `bundle.tar.gz`.
+- Bundle your build output into `bundle.tar.gz` (defaults to `dist/`, overridable with `--build-dir`).
 - Upload the archive to ForgeKit hosting.
+
+If a `forgekit.json` file exists it will be used to auto-detect the build directory based on the scaffolded stack.
+The deploy endpoint can be customized with the `FORGEKIT_DEPLOY_URL` environment variable.
+
+Example:
+
+```bash
+forge deploy --build-dir .next
+```
 
 ## Purpose
 

--- a/bin/create.js
+++ b/bin/create.js
@@ -138,6 +138,25 @@ async function main() {
   try {
     await scaffoldProject(config);
 
+    const buildDirMap = {
+      'react-vite': 'dist',
+      'vue-vite': 'dist',
+      'sveltekit': 'build',
+      'nextjs': '.next',
+      'astro': 'dist',
+      'blazor': 'dist',
+      'godot': 'dist'
+    };
+    const forgeCfg = {
+      frontend: options.frontend,
+      backend: options.backend,
+      ui: options.ui,
+      database: options.database,
+      buildDir: buildDirMap[options.frontend] || 'dist'
+    };
+    fs.writeFileSync(path.join(projectRoot, 'forgekit.json'), JSON.stringify(forgeCfg, null, 2));
+    console.log('↳ Created forgekit.json');
+
     console.log('\n===================================================');
     console.log(`✅ Project '${options.projectName}' has been forged successfully!`);
     console.log(`📂 Located at: ${projectRoot}`);

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -12,22 +12,63 @@ const asyncExec = promisify(exec);
 
 export const command = 'deploy';
 export const describe = 'Build, bundle, and deploy to ForgeKit hosting';
-export const builder = {};
-export const handler = async () => {
+export const builder = {
+  'build-dir': {
+    type: 'string',
+    describe: 'Directory containing build output',
+  },
+};
+
+function readForgeConfig() {
+  const cfgPath = path.join(process.cwd(), 'forgekit.json');
+  if (fs.existsSync(cfgPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+    } catch {}
+  }
+  return {};
+}
+
+function detectBuildDir(argv) {
+  if (argv.buildDir) return argv.buildDir;
+  const cfg = readForgeConfig();
+  if (cfg.buildDir) return cfg.buildDir;
+  const map = {
+    'react-vite': 'dist',
+    'vue-vite': 'dist',
+    'sveltekit': 'build',
+    'nextjs': '.next',
+    'astro': 'dist',
+    'blazor': 'dist',
+    'godot': 'dist',
+  };
+  if (cfg.frontend && map[cfg.frontend]) return map[cfg.frontend];
+  const guesses = ['dist', 'build', '.next', 'out'];
+  return guesses.find(d => fs.existsSync(d)) || 'dist';
+}
+
+export const handler = async (argv = {}) => {
   const bundlePath = path.join(process.cwd(), 'bundle.tar.gz');
+  const buildDir = detectBuildDir(argv);
   try {
     const useYarn = fs.existsSync('yarn.lock');
     const buildCmd = useYarn ? 'yarn build' : 'npm run build';
     console.log('🏗️ Building project...');
     await asyncExec(buildCmd);
 
-    console.log('📦 Bundling dist/ into bundle.tar.gz...');
-    await tar.c({ gzip: true, file: bundlePath }, ['dist']);
+    if (!fs.existsSync(buildDir)) {
+      console.error(`❌ Build directory '${buildDir}' not found. Did you run the build step?`);
+      return;
+    }
+
+    console.log(`📦 Bundling ${buildDir}/ into bundle.tar.gz...`);
+    await tar.c({ gzip: true, file: bundlePath }, [buildDir]);
 
     console.log('🚀 Uploading bundle...');
     const form = new FormData();
     form.append('file', fs.createReadStream(bundlePath));
-    const res = await axios.post('http://178.156.171.10:3001/deploy_cli', form, {
+    const deployUrl = process.env.FORGEKIT_DEPLOY_URL || 'http://178.156.171.10:3001/deploy_cli';
+    const res = await axios.post(deployUrl, form, {
       headers: form.getHeaders(),
     });
     const url = res.data && res.data.url;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node test/stack-implementation.test.js",
+    "test": "node test/stack-implementation.test.js && node test/deploy-missing-dir.test.js",
     "generate-stack-docs": "node scripts/generate-stack-docs.js"
   },
   "dependencies": {

--- a/test/deploy-missing-dir.test.js
+++ b/test/deploy-missing-dir.test.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { handler } from '../commands/deploy.js';
+
+(async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fk-test-'));
+  fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ scripts: { build: 'echo build' } }));
+  process.chdir(tmp);
+  await handler({ buildDir: 'dist' });
+  assert.ok(!fs.existsSync(path.join(tmp, 'bundle.tar.gz')));
+  console.log('deploy missing dir test passed');
+})();


### PR DESCRIPTION
## Summary
- support `--build-dir` on `forge deploy`
- detect build directory via `forgekit.json`
- allow deploy endpoint override with `FORGEKIT_DEPLOY_URL`
- create `forgekit.json` when scaffolding
- add test for missing build directory
- document new deploy options

## Testing
- `npm test`