### PR TITLE
Add login command and auth for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ You can verify your environment at any time with the built in doctor command:
 forge --doctor
 ```
 
+## `forge login`
+
+Run this command to authenticate the CLI with your ForgeKit account. Your web
+browser will open to complete the login flow and the received token will be
+stored in `~/.forgekit/config.json`.
+
+Example config file:
+
+```json
+{
+  "token": "USER_JWT"
+}
+```
+
 ## `forge deploy`
 
 Run this command to publish your project. It will:
@@ -64,6 +78,9 @@ Run this command to publish your project. It will:
 - Build the project.
 - Bundle your build output into `bundle.tar.gz` (defaults to `dist/`, overridable with `--build-dir`).
 - Upload the archive to ForgeKit hosting.
+
+If you are not logged in, the command will open a browser and prompt you to
+authenticate before deploying.
 
 If a `forgekit.json` file exists it will be used to auto-detect the build directory based on the scaffolded stack.
 The deploy endpoint can be customized with the `FORGEKIT_DEPLOY_URL` environment variable.

--- a/bin/create.js
+++ b/bin/create.js
@@ -10,12 +10,14 @@ import { scaffoldProject } from '../src/scaffold.js';
 import { frontendOptions, uiOptions, backendOptions, databaseOptions, uiCompatibility, backendCompatibility, dbCompatibility } from '../src/registries/modularOptions.js';
 import { runDoctor } from '../src/doctor.js';
 import * as deployCommand from '../commands/deploy.js';
+import * as loginCommand from '../commands/login.js';
 
 async function main() {
   const projectsBaseDir = process.cwd();
 
   const argv = await yargs(hideBin(process.argv))
     .command(deployCommand)
+    .command(loginCommand)
     .option('projectName', { type: 'string', description: 'Name of the project to create' })
     .option('frontend', { type: 'string', choices: Object.keys(frontendOptions) })
     .option('ui', { type: 'string', choices: Object.keys(uiOptions) })
@@ -30,7 +32,7 @@ async function main() {
     .wrap(null)
     .parse();
 
-  if (argv._[0] === 'deploy') {
+  if (argv._[0] === 'deploy' || argv._[0] === 'login') {
     return;
   }
 

--- a/commands/login.js
+++ b/commands/login.js
@@ -1,0 +1,8 @@
+import { login } from '../src/auth.js';
+
+export const command = 'login';
+export const describe = 'Authenticate with ForgeKit';
+export const builder = {};
+export const handler = async () => {
+  await login();
+};

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import { exec } from 'child_process';
+
+const CONFIG_DIR = path.join(os.homedir(), '.forgekit');
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+
+export function getSavedToken() {
+  if (process.env.FORGEKIT_TOKEN) return process.env.FORGEKIT_TOKEN;
+  try {
+    const data = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+    const token = data.token;
+    if (!token) return null;
+    const parts = token.split('.');
+    if (parts.length === 3) {
+      const payload = JSON.parse(Buffer.from(parts[1], 'base64').toString());
+      if (!payload.exp || payload.exp * 1000 > Date.now()) {
+        return token;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+export async function login() {
+  const loginUrl =
+    'https://forgekit.ai/login?cli=true&callback=http://localhost:3456';
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, 'http://localhost:3456');
+      const token = url.searchParams.get('token');
+      if (token) {
+        try {
+          fs.mkdirSync(CONFIG_DIR, { recursive: true });
+          fs.writeFileSync(CONFIG_PATH, JSON.stringify({ token }, null, 2));
+          res.end('Login successful. You can close this window.');
+          console.log('✅ Logged in successfully');
+          server.close();
+          resolve(token);
+        } catch (err) {
+          res.statusCode = 500;
+          res.end('Failed to save token');
+          server.close();
+          reject(err);
+        }
+      } else {
+        res.statusCode = 400;
+        res.end('Missing token');
+      }
+    });
+
+    server.listen(3456, () => {
+      console.log('Opening browser for login...');
+      let command;
+      if (process.platform === 'darwin') {
+        command = `open "${loginUrl}"`;
+      } else if (process.platform === 'win32') {
+        // use cmd's start to open the default browser without spawning another shell
+        command = `start "" "${loginUrl}"`;
+      } else {
+        command = `xdg-open "${loginUrl}"`;
+      }
+      exec(command);
+    });
+  });
+}
+
+export async function ensureLoggedIn() {
+  let token = getSavedToken();
+  if (token) return token;
+  try {
+    token = await login();
+    return token;
+  } catch (err) {
+    console.error('❌ Login failed:', err.message || err);
+    return null;
+  }
+}

--- a/test/deploy-missing-dir.test.js
+++ b/test/deploy-missing-dir.test.js
@@ -8,6 +8,7 @@ import { handler } from '../commands/deploy.js';
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fk-test-'));
   fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ scripts: { build: 'echo build' } }));
   process.chdir(tmp);
+  process.env.FORGEKIT_TOKEN = 'test';
   await handler({ buildDir: 'dist' });
   assert.ok(!fs.existsSync(path.join(tmp, 'bundle.tar.gz')));
   console.log('deploy missing dir test passed');


### PR DESCRIPTION
## Summary
- implement `login` command to open browser and save auth token
- create shared auth helper with login/token utilities
- require login for `forge deploy` and send token
- wire new command into CLI and document usage
- update tests to provide a dummy token
- fix browser launch on Windows when logging in

## Testing
- `npm test`
