### PR TITLE
Use dockerignore for deployment bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,22 +76,15 @@ Example config file:
 Run this command to publish your project. It will:
 
 - Build the project.
-- Bundle your build output into `bundle.tar.gz` (defaults to `dist/`, overridable with `--build-dir`).
-- Auto-generate a `.dockerignore` based on your stack so dev-only files stay out of the bundle.
+- Bundle the project root into `bundle.tar.gz`, honoring patterns in `.dockerignore`.
+- Auto-generate a `.dockerignore` based on your stack if one is missing.
 - Upload the archive to ForgeKit hosting.
 
 If you are not logged in, the command will open a browser and prompt you to
 authenticate before deploying.
 
-If a `forgekit.json` file exists it will be used to auto-detect the build directory based on the scaffolded stack.
 The deploy endpoint can be customized with the `FORGEKIT_DEPLOY_URL` environment variable.
-The `projectName` or `slug` value in `forgekit.json` will also be sent as the project slug during deployment.
-
-Example:
-
-```bash
-forge deploy --build-dir .next
-```
+The `projectName` or `slug` value in `forgekit.json` will be sent as the project slug during deployment.
 
 ## `forge secrets:set`
 

--- a/src/utils/dockerignore.js
+++ b/src/utils/dockerignore.js
@@ -31,4 +31,21 @@ function generateDockerignore(stack, options = {}) {
   return Array.from(new Set(lines)).join('\n') + '\n';
 }
 
-export { generateDockerignore };
+import fg from 'fast-glob';
+import fs from 'fs';
+import path from 'path';
+
+async function filesFromDockerignore(cwd = process.cwd()) {
+  const dockerignorePath = path.join(cwd, '.dockerignore');
+  let ignorePatterns = [];
+  if (fs.existsSync(dockerignorePath)) {
+    ignorePatterns = fs
+      .readFileSync(dockerignorePath, 'utf-8')
+      .split(/\r?\n/)
+      .map(l => l.trim())
+      .filter(l => l && !l.startsWith('#'));
+  }
+  return fg(['**/*', '**/.*'], { cwd, dot: true, ignore: ignorePatterns });
+}
+
+export { generateDockerignore, filesFromDockerignore };

--- a/test/dockerignore-util.test.js
+++ b/test/dockerignore-util.test.js
@@ -1,7 +1,20 @@
 import assert from 'assert';
-import { generateDockerignore } from '../src/utils/dockerignore.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { generateDockerignore, filesFromDockerignore } from '../src/utils/dockerignore.js';
 
 const output = generateDockerignore('nextjs', { nextStandalone: true });
 assert.ok(output.includes('.next'), 'should include .next when standalone');
 assert.ok(output.includes('node_modules'), 'should ignore node_modules');
+
+(async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fk-di-'));
+  fs.writeFileSync(path.join(tmp, '.dockerignore'), 'ignored.txt\n');
+  fs.writeFileSync(path.join(tmp, 'ignored.txt'), '');
+  fs.writeFileSync(path.join(tmp, 'keep.txt'), '');
+  const list = await filesFromDockerignore(tmp);
+  assert.ok(list.includes('keep.txt'), 'should include files not ignored');
+  assert.ok(!list.includes('ignored.txt'), 'should exclude ignored files');
+})();
 console.log('dockerignore util test passed');


### PR DESCRIPTION
## Summary
- bundle entire project using `.dockerignore` rules
- expose helper to generate file list from `.dockerignore`
- update docs for new behaviour
- adjust tests

## Testing
- `npm test`