### PR TITLE
Load env files on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Any matching variables that exist in your local environment and start with
 time. Runtime-only secrets should still be uploaded separately via
 `forge secrets:set`.
 
+When `forge deploy` executes it will also load environment variables from
+`.env`, `.env.local` and `.env.production` if those files exist. They are read in
+that order so later files override earlier ones, while existing shell variables
+remain untouched. This ensures any detected variables are available for
+injection during the build process.
+
 ## Purpose
 
 ForgeKit aims to streamline bootstrapping modern JavaScript projects by providing a collection of ready‑to‑use stacks with minimal setup hassle.

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -10,7 +10,7 @@ import FormData from 'form-data';
 import { ensureLoggedIn } from '../src/auth.js';
 import { generateDockerfile } from '../src/utils/dockerfile.js';
 import { generateDockerignore, filesFromDockerignore } from '../src/utils/dockerignore.js';
-import { detectEnvVars } from '../src/utils/env.js';
+import { detectEnvVars, loadEnvFiles } from '../src/utils/env.js';
 
 const asyncExec = promisify(exec);
 
@@ -62,6 +62,7 @@ export const handler = async (argv = {}) => {
   const dockerfilePath = path.join(process.cwd(), 'Dockerfile');
   const dockerignorePath = path.join(process.cwd(), '.dockerignore');
 
+  loadEnvFiles(process.cwd());
   const envVarNames = await detectEnvVars(process.cwd());
   if (envVarNames.length) {
     console.log(`🧪 Injecting the following build-time environment variables: ${envVarNames.join(', ')}`);

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -2,6 +2,36 @@ import fs from 'fs';
 import path from 'path';
 import fg from 'fast-glob';
 
+// Load .env style files without requiring external dependencies
+export function loadEnvFiles(cwd = process.cwd()) {
+  const files = ['.env', '.env.local', '.env.production'];
+  const combined = {};
+  for (const file of files) {
+    const filePath = path.join(cwd, file);
+    if (!fs.existsSync(filePath)) continue;
+    try {
+      const lines = fs.readFileSync(filePath, 'utf-8').split(/\r?\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eqIdx = trimmed.indexOf('=');
+        if (eqIdx === -1) continue;
+        const key = trimmed.slice(0, eqIdx).trim();
+        let value = trimmed.slice(eqIdx + 1).trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        combined[key] = value;
+      }
+    } catch {}
+  }
+  for (const [k, v] of Object.entries(combined)) {
+    if (!Object.prototype.hasOwnProperty.call(process.env, k)) {
+      process.env[k] = v;
+    }
+  }
+}
+
 const ALLOWED_PREFIXES = ['VITE_', 'NEXT_PUBLIC_'];
 
 function envAllowed(name) {


### PR DESCRIPTION
## Summary
- load env files before calling `detectEnvVars`
- add helper to parse `.env`, `.env.local`, `.env.production`
- document automatic env loading in README

## Testing
- `npm test`